### PR TITLE
이미지 byte array 로 전달하는 API 구현

### DIFF
--- a/thumbnail/src/main/kotlin/tis/S3Config.kt
+++ b/thumbnail/src/main/kotlin/tis/S3Config.kt
@@ -1,4 +1,4 @@
-package tis.presign
+package tis
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/thumbnail/src/main/kotlin/tis/S3Config.kt
+++ b/thumbnail/src/main/kotlin/tis/S3Config.kt
@@ -1,5 +1,7 @@
 package tis
 
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.sdk.kotlin.services.s3.S3Client
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "s3.config")
@@ -9,3 +11,13 @@ class S3Config(
     val accessKeyId: String,
     val secretAccessKey: String,
 )
+
+suspend fun s3Client(
+    s3Config: S3Config
+) = S3Client.fromEnvironment {
+    region = s3Config.region
+    credentialsProvider = StaticCredentialsProvider {
+        accessKeyId = s3Config.accessKeyId
+        secretAccessKey = s3Config.secretAccessKey
+    }
+}

--- a/thumbnail/src/main/kotlin/tis/presign/PreSignService.kt
+++ b/thumbnail/src/main/kotlin/tis/presign/PreSignService.kt
@@ -1,11 +1,10 @@
 package tis.presign
 
-import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
-import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.sdk.kotlin.services.s3.presigners.presignPutObject
 import org.springframework.stereotype.Service
 import tis.S3Config
+import tis.s3Client
 import kotlin.time.Duration.Companion.hours
 
 @Service
@@ -18,17 +17,8 @@ class PreSignService(
             key = filename
         }
 
-        val environmentCredentialsProvider = StaticCredentialsProvider {
-            accessKeyId = s3Config.accessKeyId
-            secretAccessKey = s3Config.secretAccessKey
-        }
-
-        val preSignedRequest = S3Client
-            .fromEnvironment {
-                region = s3Config.region
-                credentialsProvider = environmentCredentialsProvider
-            }
-            .presignPutObject(unsignedRequest, 24.hours)
+        val preSignedRequest = s3Client(s3Config)
+            .presignPutObject(unsignedRequest, 1.hours)
 
         return preSignedRequest.url.toString()
     }

--- a/thumbnail/src/main/kotlin/tis/presign/PreSignService.kt
+++ b/thumbnail/src/main/kotlin/tis/presign/PreSignService.kt
@@ -5,6 +5,7 @@ import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.sdk.kotlin.services.s3.presigners.presignPutObject
 import org.springframework.stereotype.Service
+import tis.S3Config
 import kotlin.time.Duration.Companion.hours
 
 @Service

--- a/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailController.kt
+++ b/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailController.kt
@@ -1,7 +1,6 @@
 package tis.thumbnail;
 
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 

--- a/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailController.kt
+++ b/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailController.kt
@@ -1,0 +1,21 @@
+package tis.thumbnail;
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ThumbnailController(
+    private val thumbnailService: ThumbnailService
+) {
+    @GetMapping("/thumnails")
+    suspend fun getImage(@RequestParam(required = true) filename: String): ThumbnailResponse {
+        return thumbnailService.getImage(filename)
+    }
+
+    @GetMapping("/thumnails/all")
+    suspend fun getImages(): ThumbnailResponses {
+        return thumbnailService.getImages()
+    }
+}

--- a/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailResponse.kt
+++ b/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailResponse.kt
@@ -1,0 +1,19 @@
+package tis.thumbnail
+
+data class ThumbnailResponse(
+    val filename: String,
+    val file: ByteArray? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ThumbnailResponse
+
+        return filename == other.filename
+    }
+
+    override fun hashCode(): Int {
+        return filename.hashCode()
+    }
+}

--- a/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailResponses.kt
+++ b/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailResponses.kt
@@ -1,0 +1,5 @@
+package tis.thumbnail
+
+data class ThumbnailResponses(
+    val thumbnails: List<ThumbnailResponse>
+)

--- a/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailService.kt
+++ b/thumbnail/src/main/kotlin/tis/thumbnail/ThumbnailService.kt
@@ -1,0 +1,39 @@
+package tis.thumbnail;
+
+import aws.sdk.kotlin.services.s3.model.GetObjectRequest
+import aws.sdk.kotlin.services.s3.model.ListObjectsRequest
+import aws.smithy.kotlin.runtime.content.toByteArray
+import org.springframework.stereotype.Service
+import tis.S3Config
+import tis.s3Client
+
+@Service
+class ThumbnailService(
+    private val s3Config: S3Config
+) {
+    suspend fun getImages(): ThumbnailResponses {
+        return ThumbnailResponses(s3Client(s3Config).use { s3 ->
+            val response = s3.listObjects(ListObjectsRequest {
+                bucket = s3Config.bucket
+            })
+            return@use response.contents?.mapNotNull { myObject ->
+                myObject.key?.let {
+                    getImage(it)
+                }
+            } ?: emptyList()
+        })
+    }
+
+    suspend fun getImage(filename: String): ThumbnailResponse {
+        return s3Client(s3Config).use { s3 ->
+            runCatching {
+                s3.getObject(GetObjectRequest {
+                    key = filename
+                    bucket = s3Config.bucket
+                }) { resp ->
+                    return@getObject ThumbnailResponse(filename, resp.body?.toByteArray())
+                }
+            }.getOrDefault(ThumbnailResponse(filename))
+        }
+    }
+}


### PR DESCRIPTION
### Description

이미지를 전달받는 형식은 다음과 같습니다. `runCatching`을 활용한 이유는 동일한 키를 가진 파일이 없으면 예외를 던졌습니다. async 로 던져지는거라 캐치하기 위해서는 코루틴에서 제공하는 방법을 사용해야 했습니다. 덕분에 깔끔하게 처리할 수 있었습니다.

```kotlin
suspend fun getImage(filename: String): ThumbnailResponse {
    return s3Client(s3Config).use { s3 ->
        runCatching {
            s3.getObject(GetObjectRequest {
                key = filename
                bucket = s3Config.bucket
            }) { resp ->
                return@getObject ThumbnailResponse(filename, resp.body?.toByteArray())
            }
        }.getOrDefault(ThumbnailResponse(filename))
    }
}
```

음,,, 이미지가 정말로 효율적으로 전달되는게 맞나..? ㅋㅋㅋ 일단 구현은 먼저 해두고 최적화를 차근차근 진행해봐야겠어.

